### PR TITLE
Specify C99 standard when compiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
     packages=['micall', 'micall.core', 'micall.utils', 'micall.alignment'],
     scripts=['bin/micall'],
     ext_modules=[Extension('micall.alignment._gotoh2',
-                           sources=['micall/alignment/src/_gotoh2.c'])],
+                           sources=['micall/alignment/src/_gotoh2.c'],
+                           extra_compile_args=["-std=c99"])],
     package_data={'micall':
                       ['projects.json',
                        'alignment/models/*.csv'],


### PR DESCRIPTION
Related to #10.

Add an extra compiler argument to specify that the compiler should use the C99 standard.